### PR TITLE
:middle_finger: 

### DIFF
--- a/Inc/stm32g0xx_hal_conf.h
+++ b/Inc/stm32g0xx_hal_conf.h
@@ -176,7 +176,7 @@ in voltage and temperature.*/
 #define  VDD_VALUE                    (3300UL) /*!< Value of VDD in mv */
 #define  TICK_INT_PRIORITY            ((1UL<<__NVIC_PRIO_BITS) - 1UL) /*!< tick interrupt priority */
 #define  USE_RTOS                     0U
-#define  PREFETCH_ENABLE              1U
+#define  PREFETCH_ENABLE              0U
 #define  INSTRUCTION_CACHE_ENABLE     1U
 
 /* ################## SPI peripheral configuration ########################## */

--- a/Src/stm32g0xx_hal.c
+++ b/Src/stm32g0xx_hal.c
@@ -155,6 +155,8 @@ HAL_StatusTypeDef HAL_Init(void)
 
 #if (PREFETCH_ENABLE != 0U)
   __HAL_FLASH_PREFETCH_BUFFER_ENABLE();
+#else
+  __HAL_FLASH_PREFETCH_BUFFER_DISABLE();
 #endif /* PREFETCH_ENABLE */
 
   /* Use SysTick as time base source and configure 1ms tick (default clock after Reset is HSI) */


### PR DESCRIPTION
Fix of errata 2.2.10 for stm32g0b1 ([link](https://www.st.com/resource/en/errata_sheet/es0548-stm32g0b1xbxcxe-device-errata-stmicroelectronics.pdf)).


```
   2.2.10 Prefetch failure when branching across Flash memory banks Description

    In rare cases, the code prefetch may fail upon branching and function calls across Flash memory banks, regardless of the DUAL_BANK and nSWAP_BANK option byte settings. The failing prefetch then provides an incorrect data to the CPU, which causes code execution corruption and may lead to HardFault interrupt.

    Note: The following uses of the dual bank functionality remain safe:

        EEPROM emulation or other data storage in bank 2
        bank 2 used as a download or backup slot for firmware
        mirroring the code in the banks and using bank swapping upon reset
        branching and function calls across Flash memory banks, with the prefetch function deactivated

    Workaround
        None.
```
